### PR TITLE
Correct Oracle Library Path

### DIFF
--- a/build/Windows/build.sh
+++ b/build/Windows/build.sh
@@ -89,7 +89,7 @@ function get_oracle_sdk_include_dir() {
 function get_oracle_lib_dir() {
   pushd "$TEMP_BUILD_DIR/basiclite" > /dev/null
   latest_ver=$(find . -maxdepth 1 -type d | egrep -ve '^\.$' | sort | tail -1)
-  cd "$TEMP_BUILD_DIR/sdk/${latest_ver}"/sdk/lib/msvc/vc11
+  cd "$TEMP_BUILD_DIR/sdk/${latest_ver}"/sdk/lib/msvc
   ora_client_dir=`cmd /c cd`
   popd > /dev/null
 


### PR DESCRIPTION
build fails on Windows with error saying "oci.dll" cannot be opened. Root cause revealed incorrect path used for OCI_LIB_DIR
